### PR TITLE
Add compatibility updates for use with OMP 3.3

### DIFF
--- a/QuickSubmitForm.inc.php
+++ b/QuickSubmitForm.inc.php
@@ -50,7 +50,8 @@ class QuickSubmitForm extends Form {
 		}
 
 		if ($submissionId = $request->getUserVar('submissionId')) {
-			$submissionDao = Application::getSubmissionDAO();
+			/** @var SubmissionDAO $submissionDao */
+			$submissionDao = DAORegistry::getDAO('SubmissionDAO');
 			$this->_submission = $submissionDao->getById($submissionId);
 			if ($this->_submission->getContextId() != $this->_context->getId()) throw new Exeption('Submission not in context!');
 			$this->_submission->setLocale($this->getDefaultFormLocale());
@@ -222,7 +223,8 @@ class QuickSubmitForm extends Form {
 			$seriesOptions = $seriesDao->getTitlesByContextId($this->_context->getId());
 
 			// Create and insert a new submission
-			$submissionDao = Application::getSubmissionDAO();
+			/** @var SubmissionDAO $submissionDao */
+			$submissionDao = DAORegistry::getDAO('SubmissionDAO');
 			$this->_submission = $submissionDao->newDataObject();
 			$this->_submission->setContextId($this->_context->getId());
 			$this->_submission->setStatus(STATUS_QUEUED);
@@ -298,7 +300,8 @@ class QuickSubmitForm extends Form {
 	 * cancel submit
 	 */
 	function cancel() {
-		$submissionDao = Application::getSubmissionDAO();
+		/** @var SubmissionDAO $submissionDao */
+		$submissionDao = DAORegistry::getDAO('SubmissionDAO');
 		$submission = $submissionDao->getById($this->getData('submissionId'));
 		if ($this->_submission->getContextId() != $this->_context->getId()) throw new Exeption('Submission not in context!');
 		if ($submission) $submissionDao->deleteById($submission->getId());
@@ -420,7 +423,7 @@ class QuickSubmitForm extends Form {
 	function getDoiSuffix($suffixGenerationStrategy, $doiPubIdPlugin, $pubObject, $context, $submission, $chapter){
 		switch ($suffixGenerationStrategy) {
 			case 'customId':
-				$pubIdSuffix = $pubObject->getData($suffixFieldName);
+				$pubIdSuffix = $pubObject->getData('doiSuffix');
 				break;
 
 			case 'pattern':

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -7,136 +7,138 @@
  *
  * Template for one-page submission form
  *}
-{strip}
-{assign var="pageTitle" value="plugins.importexport.quickSubmit.displayName"}
-{include file="common/header.tpl"}
-{/strip}
-<script src="{$baseUrl}/plugins/importexport/quickSubmit/js/QuickSubmitFormHandler.js"></script>
+{extends file="layouts/backend.tpl"}
 
-<script>
-	$(function() {ldelim}
-		// Attach the form handler.
-		$('#quickSubmitForm').pkpHandler('$.pkp.plugins.importexport.quickSubmit.js.QuickSubmitFormHandler');
-	{rdelim});
-	
-</script>
+{block name="page"}
+	<h1 class="app__pageHeading">
+		{translate key="plugins.importexport.quickSubmit.displayName"}
+	</h1>
 
-<div id="quickSubmitPlugin" style="background:#fff;" class="pkp_page_content pkp_pageQuickSubmit"> 
-	<p>{translate key="plugins.importexport.quickSubmit.descriptionLong"}</p>
+	<script src="{$baseUrl}/plugins/importexport/quickSubmit/js/QuickSubmitFormHandler.js"></script>
 
-	<form class="pkp_form" id="quickSubmitForm" method="post" action="{plugin_url path="saveSubmit"}">
-		<input type="hidden" name="reloadForm" id="reloadForm" value="0" />
+	<script>
+		$(function() {ldelim}
+			// Attach the form handler.
+			$('#quickSubmitForm').pkpHandler('$.pkp.plugins.importexport.quickSubmit.js.QuickSubmitFormHandler');
+		{rdelim});
 
-		{if $submissionId}
-		    <input type="hidden" name="submissionId" value="{$submissionId|escape}" />
-		{/if}
-		{if $issuesPublicationDates}
-		    {fbvElement type="hidden" id="issuesPublicationDates" value=$issuesPublicationDates}
-		{/if}
+	</script>
 
-		{csrf}
-		{include file="controllers/notification/inPlaceNotification.tpl" notificationId="quickSubmitFormNotification"}
+	<div id="quickSubmitPlugin" class="app__contentPanel pkp_pageQuickSubmit">
+		<p>{translate key="plugins.importexport.quickSubmit.descriptionLong"}</p>
 
-		{fbvFormSection label="monograph.coverImage" class=$wizardClass}
-			<div id="{$openCoverImageLinkAction->getId()}" class="pkp_linkActions">
-				{include file="linkAction/linkAction.tpl" action=$openCoverImageLinkAction contextId="quickSubmitForm"}
-			</div>
-		{/fbvFormSection}
+		<form class="pkp_form" id="quickSubmitForm" method="post" action="{plugin_url path="saveSubmit"}">
+			<input type="hidden" name="reloadForm" id="reloadForm" value="0" />
 
-		{* There is only one supported submission locale; choose it invisibly *}
-		{if count($supportedSubmissionLocaleNames) == 1}
-		    {foreach from=$supportedSubmissionLocaleNames item=localeName key=locale}
-		        {fbvElement type="hidden" id="locale" value=$locale}
-		    {/foreach}
+			{if $submissionId}
+				<input type="hidden" name="submissionId" value="{$submissionId|escape}" />
+			{/if}
+			{if $issuesPublicationDates}
+				{fbvElement type="hidden" id="issuesPublicationDates" value=$issuesPublicationDates}
+			{/if}
 
-		{* There are several submission locales available; allow choice *}
-		{else}
-		    {fbvFormSection title="submission.submit.submissionLocale" size=$fbvStyles.size.MEDIUM for="locale"}
-		        {fbvElement label="submission.submit.submissionLocaleDescription" required="true" type="select" id="locale" from=$supportedSubmissionLocaleNames selected=$locale translate=false}
-		    {/fbvFormSection}
-		{/if}
+			{csrf}
+			{include file="controllers/notification/inPlaceNotification.tpl" notificationId="quickSubmitFormNotification"}
 
-		{fbvFormSection list="true" label="submission.workflowType" description="submission.workflowType.description"}
-			{fbvElement type="radio" name="workType" id="isEditedVolume-0" value=$smarty.const.WORK_TYPE_AUTHORED_WORK checked=$workType|compare:$smarty.const.WORK_TYPE_EDITED_VOLUME:false:true label="submission.workflowType.authoredWork"}
-			{fbvElement type="radio" name="workType" id="isEditedVolume-1" value=$smarty.const.WORK_TYPE_EDITED_VOLUME checked=$workType|compare:$smarty.const.WORK_TYPE_EDITED_VOLUME label="submission.workflowType.editedVolume"}
-		{/fbvFormSection}
+			{fbvFormSection label="monograph.coverImage" class=$wizardClass}
+				<div id="{$openCoverImageLinkAction->getId()}" class="pkp_linkActions">
+					{include file="linkAction/linkAction.tpl" action=$openCoverImageLinkAction contextId="quickSubmitForm"}
+				</div>
+			{/fbvFormSection}
 
-		{include file="submission/form/series.tpl" readOnly=$formParams.readOnly}
+			{* There is only one supported submission locale; choose it invisibly *}
+			{if count($supportedSubmissionLocaleNames) == 1}
+				{foreach from=$supportedSubmissionLocaleNames item=localeName key=locale}
+					{fbvElement type="hidden" id="locale" value=$locale}
+				{/foreach}
 
-		{include file="core:submission/form/categories.tpl"}
-
-		{include file="core:submission/submissionMetadataFormTitleFields.tpl"}
-
-		{include file="submission/submissionMetadataFormFields.tpl"}
-
-		{fbvFormArea id="contributors"}
-			<!--  Contributors -->
-			{capture assign="authorGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="grid.users.author.AuthorGridHandler" op="fetchGrid" submissionId=$submissionId publicationId=$publicationId escape=false}{/capture}
-			{load_url_in_div id="authorsGridContainer" url=$authorGridUrl}
-
-			{$additionalContributorsFields}
-		{/fbvFormArea}
-
-		{fbvFormArea id="representations-grid"}
-			{capture assign="representationsGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="grid.catalogEntry.PublicationFormatGridHandler" op="fetchGrid" submissionId=$submissionId publicationId=$publicationId escape=false}{/capture}
-			{load_url_in_div id="formatsGridContainer"|uniqid url=$representationsGridUrl}
-		{/fbvFormArea}
-
-		{fbvFormArea id="chapters"}
-			{capture assign=chaptersGridUrl}{url router=$smarty.const.ROUTE_COMPONENT  component="grid.users.chapter.ChapterGridHandler" op="fetchGrid" submissionId=$submissionId publicationId=$publicationId escape=false}{/capture}
-			{load_url_in_div id="chaptersGridContainer" url=$chaptersGridUrl}
-		{/fbvFormArea}
-
-		{if $pubIds}
-			{foreach from=$pubIdPlugins item=pubIdPlugin}
-				{assign var=pubIdAssignFile value=$pubIdPlugin->getPubIdAssignFile()}
-				{assign var=canBeAssigned value=$pubIdPlugin->canBeAssigned($publication)}
-				{include file="$pubIdAssignFile" pubIdPlugin=$pubIdPlugin pubObject=$publication canBeAssigned=$canBeAssigned}
-			{/foreach}
-		{/if}
-
-		{if $assignPublicationDoi || $assignChapterDoi}
-			{fbvFormArea id="addDois"}
-				{fbvFormSection list="true"}
-				{if $assignPublicationDoi}
-					{fbvElement type="checkbox" id="assignPublicationDoi" value="1" checked=$assignPublicationDoi label="plugins.importexport.quickSubmit.assignPublicationDoi"}
-				{/if}
-				{if $assignChapterDoi}
-					{fbvElement type="checkbox" id="assignChapterDoi" value="1" checked=$assignChapterDoi label="plugins.importexport.quickSubmit.assignChapterDoi"}
-				{/if}
+			{* There are several submission locales available; allow choice *}
+			{else}
+				{fbvFormSection title="submission.submit.submissionLocale" size=$fbvStyles.size.MEDIUM for="locale"}
+					{fbvElement label="submission.submit.submissionLocaleDescription" required="true" type="select" id="locale" from=$supportedSubmissionLocaleNames selected=$locale translate=false}
 				{/fbvFormSection}
-			{/fbvFormArea}			
-		{/if}
+			{/if}
 
-		{fbvFormArea id="permissions"}
-			{fbvFormSection list="true" label="submission.licenseURL"}
-				{fbvElement type="text" id="licenseUrl" value=$licenseUrl}
+			{fbvFormSection list="true" label="submission.workflowType" description="submission.workflowType.description"}
+				{fbvElement type="radio" name="workType" id="isEditedVolume-0" value=$smarty.const.WORK_TYPE_AUTHORED_WORK checked=$workType|compare:$smarty.const.WORK_TYPE_EDITED_VOLUME:false:true label="submission.workflowType.authoredWork"}
+				{fbvElement type="radio" name="workType" id="isEditedVolume-1" value=$smarty.const.WORK_TYPE_EDITED_VOLUME checked=$workType|compare:$smarty.const.WORK_TYPE_EDITED_VOLUME label="submission.workflowType.editedVolume"}
 			{/fbvFormSection}
-			{fbvFormSection list="true" label="submission.copyrightHolder"}
-				{fbvElement type="radio" name="copyrightHolder" id="copyrightHolder-0" value="author" checked=$copyrightHolderType|compare:author label="user.role.author"}
-				{fbvElement type="radio" name="copyrightHolder" id="copyrightHolder-1" value="press" checked=$copyrightHolderType|compare:context label="context.context"}
-			{/fbvFormSection}
-		{/fbvFormArea}
 
-		{* Publishing monograph section *}
-			{fbvFormSection id='submissionPublishingSection' list="false"}
-				{fbvElement type="radio" id="submissionUnpublished" name="submissionStatus" value=0 checked=$submissionStatus|compare:false label='plugins.importexport.quickSubmit.unpublished' translate="true"}
-				{fbvElement type="radio" id="submissionPublished" name="submissionStatus" value=1 checked=$submissionStatus|compare:true label='plugins.importexport.quickSubmit.published' translate="true"}
+			{include file="submission/form/series.tpl" readOnly=$formParams.readOnly}
 
-				{fbvFormSection id='schedulePublicationDiv' list="false"}
-					{fbvFormArea id="schedulingInformationDatePublished" title="publication.datePublished"}
-						{fbvFormSection for="publishedDate"}
-							{fbvElement type="text" required=true id="datePublished" value=$datePublished translate=false label="publication.datePublished" inline=true size=$fbvStyles.size.MEDIUM class="datepicker"}
-						{/fbvFormSection}
-					{/fbvFormArea}
+			{include file="core:submission/form/categories.tpl"}
+
+			{include file="core:submission/submissionMetadataFormTitleFields.tpl"}
+
+			{include file="submission/submissionMetadataFormFields.tpl"}
+
+			{fbvFormArea id="contributors"}
+				<!--  Contributors -->
+				{capture assign="authorGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="grid.users.author.AuthorGridHandler" op="fetchGrid" submissionId=$submissionId publicationId=$publicationId escape=false}{/capture}
+				{load_url_in_div id="authorsGridContainer" url=$authorGridUrl}
+
+				{$additionalContributorsFields}
+			{/fbvFormArea}
+
+			{fbvFormArea id="representations-grid"}
+				{capture assign="representationsGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="grid.catalogEntry.PublicationFormatGridHandler" op="fetchGrid" submissionId=$submissionId publicationId=$publicationId escape=false}{/capture}
+				{load_url_in_div id="formatsGridContainer"|uniqid url=$representationsGridUrl}
+			{/fbvFormArea}
+
+			{fbvFormArea id="chapters"}
+				{capture assign=chaptersGridUrl}{url router=$smarty.const.ROUTE_COMPONENT  component="grid.users.chapter.ChapterGridHandler" op="fetchGrid" submissionId=$submissionId publicationId=$publicationId escape=false}{/capture}
+				{load_url_in_div id="chaptersGridContainer" url=$chaptersGridUrl}
+			{/fbvFormArea}
+
+			{if $pubIds}
+				{foreach from=$pubIdPlugins item=pubIdPlugin}
+					{assign var=pubIdAssignFile value=$pubIdPlugin->getPubIdAssignFile()}
+					{assign var=canBeAssigned value=$pubIdPlugin->canBeAssigned($publication)}
+					{include file="$pubIdAssignFile" pubIdPlugin=$pubIdPlugin pubObject=$publication canBeAssigned=$canBeAssigned}
+				{/foreach}
+			{/if}
+
+			{if $assignPublicationDoi || $assignChapterDoi}
+				{fbvFormArea id="addDois"}
+					{fbvFormSection list="true"}
+					{if $assignPublicationDoi}
+						{fbvElement type="checkbox" id="assignPublicationDoi" value="1" checked=$assignPublicationDoi label="plugins.importexport.quickSubmit.assignPublicationDoi"}
+					{/if}
+					{if $assignChapterDoi}
+						{fbvElement type="checkbox" id="assignChapterDoi" value="1" checked=$assignChapterDoi label="plugins.importexport.quickSubmit.assignChapterDoi"}
+					{/if}
+					{/fbvFormSection}
+				{/fbvFormArea}
+			{/if}
+
+			{fbvFormArea id="permissions"}
+				{fbvFormSection list="true" label="submission.licenseURL"}
+					{fbvElement type="text" id="licenseUrl" value=$licenseUrl}
 				{/fbvFormSection}
-				
-			{/fbvFormSection}
+				{fbvFormSection list="true" label="submission.copyrightHolder"}
+					{fbvElement type="radio" name="copyrightHolder" id="copyrightHolder-0" value="author" checked=$copyrightHolderType|compare:author label="user.role.author"}
+					{fbvElement type="radio" name="copyrightHolder" id="copyrightHolder-1" value="press" checked=$copyrightHolderType|compare:context label="context.context"}
+				{/fbvFormSection}
+			{/fbvFormArea}
 
-		{capture assign="cancelUrl"}{plugin_url path="cancelSubmit" submissionId="$submissionId"}{/capture}
+			{* Publishing monograph section *}
+				{fbvFormSection id='submissionPublishingSection' list="false"}
+					{fbvElement type="radio" id="submissionUnpublished" name="submissionStatus" value=0 checked=$submissionStatus|compare:false label='plugins.importexport.quickSubmit.unpublished' translate="true"}
+					{fbvElement type="radio" id="submissionPublished" name="submissionStatus" value=1 checked=$submissionStatus|compare:true label='plugins.importexport.quickSubmit.published' translate="true"}
 
-		{fbvFormButtons id="quickSubmit" submitText="common.save" cancelUrl=$cancelUrl cancelUrlTarget="_self"}
-	</form>
-</div>
+					{fbvFormSection id='schedulePublicationDiv' list="false"}
+						{fbvFormArea id="schedulingInformationDatePublished" title="publication.datePublished"}
+							{fbvFormSection for="publishedDate"}
+								{fbvElement type="text" required=true id="datePublished" value=$datePublished translate=false label="publication.datePublished" inline=true size=$fbvStyles.size.MEDIUM class="datepicker"}
+							{/fbvFormSection}
+						{/fbvFormArea}
+					{/fbvFormSection}
 
-{include file="common/footer.tpl"}
+				{/fbvFormSection}
+
+			{capture assign="cancelUrl"}{plugin_url path="cancelSubmit" submissionId="$submissionId"}{/capture}
+
+			{fbvFormButtons id="quickSubmit" submitText="common.save" cancelUrl=$cancelUrl cancelUrlTarget="_self"}
+		</form>
+	</div>
+{/block}

--- a/templates/submitCancel.tpl
+++ b/templates/submitCancel.tpl
@@ -7,20 +7,21 @@
  *
  * Display a message indicating that the submission was cancelled.
  *}
-{strip}
-{assign var="pageTitle" value="plugins.importexport.quickSubmit.cancel"}
-{include file="common/header.tpl"}
-{/strip}
+{extends file="layouts/backend.tpl"}
 
-<div class="pkp_page_content pkp_cancelQuickSubmit">
-	<p>
-		{translate key="plugins.importexport.quickSubmit.cancelDescription"}  
-	</p>
-	<p> 
-		<a href="{plugin_url}">
-			{translate key="plugins.importexport.quickSubmit.successReturn"}
-		</a>
-	</p>
-</div>
+{block name="page"}
+	<h1 class="app__pageHeading">
+		{translate key="plugins.importexport.quickSubmit.cancel"}
+	</h1>
 
-{include file="common/footer.tpl"}
+	<div class="app__contentPanel pkp_cancelQuickSubmit">
+		<p>
+			{translate key="plugins.importexport.quickSubmit.cancelDescription"}
+		</p>
+		<p>
+			<a href="{plugin_url}">
+				{translate key="plugins.importexport.quickSubmit.successReturn"}
+			</a>
+		</p>
+	</div>
+{/block}

--- a/templates/submitSuccess.tpl
+++ b/templates/submitSuccess.tpl
@@ -7,27 +7,29 @@
  *
  * Display a message indicating that the monograph was successfuly submitted.
  *}
-{strip}
-{assign var="pageTitle" value="plugins.importexport.quickSubmit.success"}
-{include file="common/header.tpl"}
-{/strip}
+{extends file="layouts/backend.tpl"}
 
-{capture assign="submissionUrl"}{url router=$smarty.const.ROUTE_PAGE page="workflow" op="access" stageId=$stageId submissionId=$submissionId contextId="submission" escape=false}{/capture}
+{block name="page"}
+	<h1 class="app__pageHeading">
+		{translate key="plugins.importexport.quickSubmit.success"}
+	</h1>
 
-<div class="pkp_page_content pkp_successQuickSubmit">
-	<p>
-		{translate key="plugins.importexport.quickSubmit.successDescription"}  
-	</p>
-	<p> 
-		<a href="{plugin_url}">
-			{translate key="plugins.importexport.quickSubmit.successReturn"}
-		</a>
-	</p>
-	<p> 
-		<a href="{url router=$smarty.const.ROUTE_PAGE page="workflow" op="access" path=$submissionId escape=false}">
-			{translate key="plugins.importexport.quickSubmit.goToSubmission"}
-		</a>
-	</p>
-</div>
+	{capture assign="submissionUrl"}{url router=$smarty.const.ROUTE_PAGE page="workflow" op="access" stageId=$stageId submissionId=$submissionId contextId="submission" escape=false}{/capture}
 
-{include file="common/footer.tpl"}
+	<div class="app__contentPanel pkp_successQuickSubmit">
+		<p>
+			{translate key="plugins.importexport.quickSubmit.successDescription"}
+		</p>
+		<p>
+			<a href="{plugin_url}">
+				{translate key="plugins.importexport.quickSubmit.successReturn"}
+			</a>
+		</p>
+		<p>
+			<a href="{url router=$smarty.const.ROUTE_PAGE page="workflow" op="access" path=$submissionId escape=false}">
+				{translate key="plugins.importexport.quickSubmit.goToSubmission"}
+			</a>
+		</p>
+	</div>
+
+{/block}


### PR DESCRIPTION
Hi @ajnyga,

This PR removes a deprecated DAO call and updates the templates to use the `{block}` formatting to add compatibility with OMP 3.3.

Let me know if you have any questions.

Thanks!