### PR TITLE
Submission remains in incomplete status after completion.

### DIFF
--- a/QuickSubmitForm.php
+++ b/QuickSubmitForm.php
@@ -362,7 +362,7 @@ class QuickSubmitForm extends Form
         $this->_submission->setLocale($this->getData('locale'));
         $this->_submission->setStageId(WORKFLOW_STAGE_ID_PRODUCTION);
         $this->_submission->setDateSubmitted(Core::getCurrentDate());
-        $this->_submission->setSubmissionProgress(0);
+        $this->_submission->setSubmissionProgress('');
         $this->_submission->setWorkType($this->getData('workType'));
 
         parent::execute($this->_submission, ...$functionParams);


### PR DESCRIPTION
We noticed that there is a bug in the assignment of submission progress, which results in a submission remaining in the incomplete stage even after it has been completed.
We made this minor adaptation using the [OJS plugin as a basis](https://github.com/pkp/quickSubmit/blob/08b8c1e81d5ab8733e4752bf9b1fd4d037e3992b/QuickSubmitForm.php#L411), and it seems to have been fixed.